### PR TITLE
#Fix JUnit Vintage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,9 +29,8 @@ dependencies {
 
 
     // Use JUnit test framework.
-    testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.8.1'
     testImplementation 'ch.qos.logback:logback-classic:1.3.0-alpha13'
 }
 
@@ -48,3 +47,9 @@ application {
     // Define the main class for the application.
     mainClass = 'Flex.App'
 }
+
+test {
+    useJUnitPlatform()
+}
+
+


### PR DESCRIPTION
## Overview
- JUnit5 디펜던시 추가 후에도 Junit Vintage 누락되는 현상 원인 파악
- JUnit5 포함에 대한 Junit Vintage 누락되는 현상 원인 해결

## Description
### 1. JUnit 5 의 아키텍처
- JUnit 5의 아키텍처를 세부적으로 확인해보면 다음과 같은 Hierarchy가 존재합니다.

 > JUnit 5 의 상세 구성
      > Jupiter  : JUnit 5
      > Vintage : JUnit 3,4 실행 엔진
      > Platform : JVM 에 테스트 프레임워크 실행하는 것 JVM과 JUnit 3,4,5(Jupiter + Vintage) 사이의 접착제로 볼수 있을듯

- 염두해야할 것은,>>> **Platform, Vintage, Jupiter는 Junit 5에 속하지만 한 패키지에 묶여있지는 않다**인것 같습니다.<<<
          
![Screen Shot 2022-03-19 at 11 29 14 PM](https://user-images.githubusercontent.com/61615301/159125141-712982de-59f7-4560-b397-024f06633e0a.png)
source : https://freecontent.manning.com/junit-5-architecture/#:~:text=JUnit%205%20modularity&text=Its%20architecture%20had%20to%20allow,discovering%20and%20running%20the%20tests.

</br>

### 2. 기존 원인 파악 (build.gradle)
- `testImplementation 'junit:junit:4.13.1'`는 **Vintage**로 대체 가능합니다.
-  대신 `vintage`를 디펜던시로 추가해준다. vintage를 명시적으로 추가해야만 vintage 확인가능
- `useJUnitPlatform()` 을 통해 컴파일러와 JVM, 그리고 IDE(IntelliJ) 에게 JUnit을통해서 테스트들을 실행하라고 명시해준다. 그러면 IntelliJ에서 발생하는 컴파일에러도 해결가능

![Screen Shot 2022-03-19 at 11 26 14 PM](https://user-images.githubusercontent.com/61615301/159125762-78b42fe0-898c-4215-a6c4-d13ad5d79eee.png)

</br>

### 3. Comments
- JUnit 4는 자바 7, 8 까지만 운영이 된 걸로 알고있습니다. (80% 확신)
- JUnit 5 만드는 입장에서 생각해보면 JUnit Vintage 는 JUnit 5(Jupiter) 로 마이그레이션 하는 과정을 좀 더 수월하게 하기 위한 것이지 함께 사용하라고 만든 것이 아니기때문에 분리시켜둔것이 아닐까... 하고 생각해봅니다.